### PR TITLE
feat: Implement enhanced skills section and new creative showcase

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -3,6 +3,7 @@ import Header from "./Vue/pages/Header.vue";
 import About from "./Vue/pages/About.vue";
 import Skills from "./Vue/pages/Skills.vue";
 import Portfolio from "./Vue/pages/Portfolio.vue";
+import Showcase from "./Vue/pages/Showcase.vue";
 import Contact from "./Vue/pages/Contact.vue";
 import Footer from "./Vue/pages/Footer.vue";
 </script>
@@ -13,6 +14,7 @@ import Footer from "./Vue/pages/Footer.vue";
     <About />
     <Skills />
     <Portfolio />
+    <Showcase />
     <Contact />
     <Footer />
   </div>

--- a/src/Vue/pages/Showcase.vue
+++ b/src/Vue/pages/Showcase.vue
@@ -1,0 +1,137 @@
+<script setup lang="ts">
+import { ref } from "vue";
+import Arrow from "../components/Arrow.vue";
+import data from "../../data/data.json";
+
+interface ShowcaseItem {
+  id: number;
+  title: string;
+  description: string;
+  date: string;
+  type: string;
+  imageUrl?: string;
+  link?: string;
+  tags?: string[];
+}
+
+const showcaseItems = ref<ShowcaseItem[]>(data.showcase.items);
+const heading = ref<string>(data.main.headings.showcase);
+</script>
+
+<template>
+  <section id="showcase" class="light-section">
+    <div class="container-fluid">
+      <h1 class="section-header">{{ heading }}</h1>
+
+      <div class="showcase-grid">
+        <div class="showcase-card" v-for="item in showcaseItems" :key="item.id">
+          <img v-if="item.imageUrl" :src="item.imageUrl" :alt="item.title" class="showcase-image" />
+          <h3>
+            <a v-if="item.link" :href="item.link" target="_blank" rel="noopener noreferrer">{{ item.title }}</a>
+            <template v-else>{{ item.title }}</template>
+          </h3>
+          <p class="meta-info">
+            <span class="type">{{ item.type }}</span> | <span class="date">{{ item.date }}</span>
+          </p>
+          <p class="description">{{ item.description }}</p>
+          <div class="tags" v-if="item.tags && item.tags.length">
+            <strong>Tags:</strong> 
+            <span v-for="tag in item.tags" :key="tag" class="tag">{{ tag }}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <Arrow />
+  </section>
+</template>
+
+<style scoped>
+.light-section {
+  padding: 60px 0;
+  background-color: #f8f9fa; /* Or your desired light background color */
+}
+.section-header {
+  text-align: center;
+  margin-bottom: 50px;
+  font-size: 2.5rem;
+  font-weight: bold;
+  color: #333;
+}
+.showcase-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 20px;
+  padding: 0 15px; /* Add some padding if container-fluid doesn't have enough */
+}
+.showcase-card {
+  background-color: #fff;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  padding: 20px;
+  box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+.showcase-card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 6px 12px rgba(0,0,0,0.15);
+}
+.showcase-image {
+  width: 100%;
+  max-height: 200px; /* Limit image height */
+  object-fit: cover; /* Cover the area, might crop */
+  border-radius: 4px;
+  margin-bottom: 15px;
+}
+.showcase-card h3 {
+  font-size: 1.5rem;
+  margin-top: 0;
+  margin-bottom: 10px;
+  color: #007bff; /* Bootstrap primary color for links/headings */
+}
+.showcase-card h3 a {
+  text-decoration: none;
+  color: inherit;
+}
+.showcase-card h3 a:hover {
+  text-decoration: underline;
+}
+.meta-info {
+  font-size: 0.9rem;
+  color: #6c757d; /* Bootstrap muted text color */
+  margin-bottom: 10px;
+}
+.meta-info .type {
+  font-weight: bold;
+}
+.description {
+  font-size: 1rem;
+  line-height: 1.6;
+  color: #495057;
+  margin-bottom: 15px;
+}
+.tags {
+  font-size: 0.9rem;
+}
+.tags strong {
+  color: #333;
+}
+.tag {
+  display: inline-block;
+  background-color: #007bff;
+  color: white;
+  padding: 3px 8px;
+  border-radius: 4px;
+  margin-right: 5px;
+  margin-bottom: 5px;
+  font-size: 0.8rem;
+}
+/* Responsive adjustments if necessary */
+@media (max-width: 768px) {
+  .showcase-grid {
+    grid-template-columns: 1fr; /* Stack cards on smaller screens */
+  }
+  .section-header {
+    font-size: 2rem;
+  }
+}
+</style>

--- a/src/Vue/pages/Skills.vue
+++ b/src/Vue/pages/Skills.vue
@@ -39,27 +39,27 @@ const setCategory = (event: Event) => {
       <h1 class="section-header">{{ heading }}</h1>
 
       <!-- start of filters  -->
-<!--      <div class="row filters">-->
-<!--        <ul-->
-<!--            class="list-inline mx-auto"-->
-<!--            data-aos="fade-right"-->
-<!--            data-aos-duration="1000"-->
-<!--        >-->
-<!--          <li-->
-<!--              v-for="item in skills"-->
-<!--              :key="item.category"-->
-<!--              class="list-inline-item filter"-->
-<!--          >-->
-<!--            <a-->
-<!--                class="nav-item"-->
-<!--                :class="{ active: item.category === currentCategory }"-->
-<!--                :data-category="item.category"-->
-<!--                @click="setCategory"-->
-<!--            >{{ item.category }}</a-->
-<!--            >-->
-<!--          </li>-->
-<!--        </ul>-->
-<!--      </div>-->
+      <div class="row filters">
+        <ul
+            class="list-inline mx-auto"
+            data-aos="fade-right"
+            data-aos-duration="1000"
+        >
+          <li
+              v-for="item in skills"
+              :key="item.category"
+              class="list-inline-item filter"
+          >
+            <a
+                class="nav-item"
+                :class="{ active: item.category === currentCategory }"
+                :data-category="item.category"
+                @click="setCategory"
+            >{{ item.category }}</a
+            >
+          </li>
+        </ul>
+      </div>
       <!-- end of filters  -->
 
       <!-- start of skill container  -->

--- a/src/data/data.json
+++ b/src/data/data.json
@@ -10,6 +10,7 @@
       "about": "About",
       "skills": "Skills",
       "portfolio": "Portfolio",
+      "showcase": "Creative Showcase",
       "contact": "Contact"
     }
   },
@@ -26,45 +27,45 @@
     ]
   },
   "skills": {
-    "defaultCategory": "Programming",
-
+    "defaultCategory": "Languages & Frameworks",
     "categories": [
       {
-        "category": "Programming",
+        "category": "Languages & Frameworks",
         "faClass": "fas fa-code",
         "skillList": [
-          {
-            "name": "TypeScript",
-            "level": "100"
-          },
-          {
-            "name": "C#",
-            "level": "80"
-          },
-          {
-            "name": "Python",
-            "level": "30"
-          },
-          {
-            "name": "PostgreSQL",
-            "level": "60"
-          },
-          {
-            "name": "AWS",
-            "level": "70"
-          },
-          {
-            "name": "JavaScript",
-            "level": "100"
-          },
-          {
-            "name": "CSS",
-            "level": "80"
-          },
-          {
-            "name": "HTML",
-            "level": "100"
-          }
+          { "name": "TypeScript", "level": "100" },
+          { "name": "JavaScript", "level": "100" },
+          { "name": "C#", "level": "80" },
+          { "name": ".NET", "level": "75" },
+          { "name": "Angular", "level": "70" },
+          { "name": "Python", "level": "30" }
+        ]
+      },
+      {
+        "category": "Back-end Development",
+        "faClass": "fas fa-cogs",
+        "skillList": [
+          { "name": "API Creation", "level": "85" },
+          { "name": "gRPC", "level": "70" },
+          { "name": "Protobuf", "level": "65" },
+          { "name": "SQL", "level": "70" },
+          { "name": "PostgreSQL", "level": "60" }
+        ]
+      },
+      {
+        "category": "Cloud & DevOps",
+        "faClass": "fas fa-cloud",
+        "skillList": [
+          { "name": "AWS", "level": "70" },
+          { "name": "SharePoint Development", "level": "60" }
+        ]
+      },
+      {
+        "category": "Design & UI",
+        "faClass": "fas fa-palette",
+        "skillList": [
+          { "name": "HTML", "level": "100" },
+          { "name": "CSS", "level": "80" }
         ]
       }
     ]
@@ -117,7 +118,6 @@
     "email": "jamesthomaschapman99@gmail.com",
     "resumeLink": "",
     "form": true,
-
     "social": [
       {
         "name": "linkedin",
@@ -133,6 +133,30 @@
         "name": "instagram",
         "url": "https://www.instagram.com/bobross_thejoyofpainting/",
         "faClass": "fab fa-instagram"
+      }
+    ]
+  },
+  "showcase": {
+    "items": [
+      {
+        "id": 1,
+        "title": "Alien Title Sequence in CSS",
+        "description": "A recreation of the iconic Alien movie title sequence using only HTML and CSS animations. Explores advanced CSS techniques for visual effects.",
+        "date": "2024-03-15",
+        "type": "Creative Coding",
+        "imageUrl": "src/assets/images/portfolio/alien-sequence-preview.jpg",
+        "link": "#portfolio",
+        "tags": ["CSS", "Animation", "Movies"]
+      },
+      {
+        "id": 2,
+        "title": "Exploring Predictive Models",
+        "description": "An ongoing research project into machine learning predictive models. This placeholder will be updated with findings and potential applications.",
+        "date": "2024-04-01",
+        "type": "Machine Learning",
+        "imageUrl": "src/assets/images/portfolio/ml-research-preview.jpg",
+        "link": "",
+        "tags": ["Python", "AI", "Research"]
       }
     ]
   },


### PR DESCRIPTION
This was created by Google AI Jules as a test to see how it does with new features being created. 

This commit introduces two main features:

1.  Enhanced Skills Section:
    - I've updated `data.json` to include more detailed skill categories: "Languages & Frameworks", "Back-end Development", "Cloud & DevOps", and "Design & UI".
    - I reorganised existing skills and added new ones from the README into these categories with defined experience levels.
    - I enabled the category filtering UI in `Skills.vue`, allowing you to view skills by selected category.

2.  New Creative Showcase Section:
    - I created a new `Showcase.vue` component to display projects, articles, or creative work.
    - I added a corresponding "showcase" section to `data.json` to store content for this new area, including placeholder items for the "Alien Title Sequence" and "Machine Learning Research".
    - I added a heading for the "Creative Showcase" in `data.json` and updated the component to use it.
    - I integrated the `Showcase.vue` component into `App.vue`, placing it after the Portfolio section.

These changes aim to provide a more detailed and organized view of skills and offer a new space to highlight creative projects and research.